### PR TITLE
fix(autofix): stop orphaning fix branches on PR metadata errors

### DIFF
--- a/.github/scripts/auto_fix_agent.py
+++ b/.github/scripts/auto_fix_agent.py
@@ -43,10 +43,13 @@ PIPELINE  = os.environ.get("PIPELINE", "CI")
 HEAD_SHA  = os.environ.get("HEAD_SHA", "")
 GH_TOKEN  = os.environ.get("GITHUB_TOKEN", "")
 
-# Slack notification — reuses the same bot token / channel as bug_report_slack.
-# No webhook needed: chat.postMessage works with the bot token directly.
+# Slack notification — uses the bot token via chat.postMessage (no webhook).
+# PR-review pings go to the dedicated #ci-pr-review channel
+# (PR_REVIEW_CHANNEL_ID); fall back to the bug-reports channel if it isn't set
+# so we never silently lose a notification.
 SLACK_TOKEN   = os.environ.get("SLACK_BOT_TOKEN", "")
-SLACK_CHANNEL = os.environ.get("BUG_REPORTS_CHANNEL_ID", "")
+SLACK_CHANNEL = (os.environ.get("PR_REVIEW_CHANNEL_ID", "")
+                 or os.environ.get("BUG_REPORTS_CHANNEL_ID", ""))
 
 MAX_LOG_CHARS  = 18000
 MAX_FILE_CHARS = 12000

--- a/.github/scripts/auto_fix_agent.py
+++ b/.github/scripts/auto_fix_agent.py
@@ -8,7 +8,7 @@ Workflow:
   2. Find which test files are failing
   3. Call LLM (rotating through all configured providers) with logs + files
   4. Apply the suggested file patches
-  5. Push a fix branch and open a PR with alexpavsky as reviewer
+  5. Push a fix branch and open a PR for human review (labelled `bug`)
 
 The agent never merges — it only opens a PR for human review.
 
@@ -378,36 +378,42 @@ def create_pr(fixes: list[dict]) -> None:
 *This PR was created automatically by the auto-fix agent. Review carefully before merging.*
 """
 
-    result = subprocess.run(
+    # Create the PR with only the flags that can't fail. A bad --reviewer or a
+    # non-existent --label makes `gh pr create` exit non-zero AFTER pushing the
+    # branch, which orphans it with no PR. Metadata is applied best-effort below.
+    create = subprocess.run(
         [
             "gh", "pr", "create",
             "--title", f"fix: auto-fix {PIPELINE} ({short_sha})",
             "--body", pr_body,
-            "--reviewer", "alexpavsky",
-            "--label", "bug-fix",
             "--head", branch,
             "--base", "master",
         ],
         capture_output=True,
         text=True,
     )
-    if result.returncode == 0:
-        print(f"  ✅ PR created: {result.stdout.strip()}")
-    else:
-        print(f"  ⚠ PR creation failed: {result.stderr.strip()}", file=sys.stderr)
-        # Try without reviewer in case alexpavsky is not yet a collaborator
-        subprocess.run(
-            [
-                "gh", "pr", "create",
-                "--title", f"fix: auto-fix {PIPELINE} ({short_sha})",
-                "--body", pr_body,
-                "--label", "bug-fix",
-                "--head", branch,
-                "--base", "master",
-            ],
-            check=True,
+    if create.returncode != 0:
+        print(f"  ⚠ PR creation failed: {create.stderr.strip()}", file=sys.stderr)
+        return
+    pr_url = create.stdout.strip()
+    print(f"  ✅ PR created: {pr_url}")
+
+    # Best-effort metadata — a missing label/reviewer must never orphan the PR.
+    # Reviewer is opt-in via PR_REVIEWER env (must be a real repo collaborator).
+    reviewer = os.environ.get("PR_REVIEWER", "").strip()
+    label = subprocess.run(
+        ["gh", "pr", "edit", pr_url, "--add-label", "bug"],
+        capture_output=True, text=True,
+    )
+    if label.returncode != 0:
+        print(f"  (label not applied: {label.stderr.strip()})", file=sys.stderr)
+    if reviewer:
+        rev = subprocess.run(
+            ["gh", "pr", "edit", pr_url, "--add-reviewer", reviewer],
+            capture_output=True, text=True,
         )
-        print("  ✅ PR created (without reviewer)")
+        if rev.returncode != 0:
+            print(f"  (reviewer not added: {rev.stderr.strip()})", file=sys.stderr)
 
 
 # ---------------------------------------------------------------------------

--- a/.github/scripts/auto_fix_agent.py
+++ b/.github/scripts/auto_fix_agent.py
@@ -43,6 +43,11 @@ PIPELINE  = os.environ.get("PIPELINE", "CI")
 HEAD_SHA  = os.environ.get("HEAD_SHA", "")
 GH_TOKEN  = os.environ.get("GITHUB_TOKEN", "")
 
+# Slack notification — reuses the same bot token / channel as bug_report_slack.
+# No webhook needed: chat.postMessage works with the bot token directly.
+SLACK_TOKEN   = os.environ.get("SLACK_BOT_TOKEN", "")
+SLACK_CHANNEL = os.environ.get("BUG_REPORTS_CHANNEL_ID", "")
+
 MAX_LOG_CHARS  = 18000
 MAX_FILE_CHARS = 12000
 
@@ -341,6 +346,37 @@ def git(*args: str) -> str:
     return result.stdout.strip()
 
 
+def slack_notify(pr_url: str, fixes: list[dict]) -> None:
+    """Best-effort Slack ping that a PR needs review. Uses the bot token +
+    channel that already exist as repo secrets — no webhook required.
+    GitHub never emails about PRs the bot's own account authored, so this is
+    how the human actually finds out. Never raises."""
+    if not SLACK_TOKEN or not SLACK_CHANNEL:
+        print("  (slack notify skipped — SLACK_BOT_TOKEN/BUG_REPORTS_CHANNEL_ID not set)")
+        return
+    changed = ", ".join(sorted({f["file_path"] for f in fixes})) or "test files"
+    text = (f":robot_face: *Auto-fix PR ready for review* — {PIPELINE}\n"
+            f"Files: {changed}\n{pr_url}")
+    payload = json.dumps({"channel": SLACK_CHANNEL, "text": text}).encode()
+    req = urllib.request.Request(
+        "https://slack.com/api/chat.postMessage",
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {SLACK_TOKEN}",
+            "Content-Type": "application/json; charset=utf-8",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as r:
+            resp = json.loads(r.read())
+        if resp.get("ok"):
+            print("  💬 Slack notification sent")
+        else:
+            print(f"  ⚠ Slack notify error: {resp.get('error')}", file=sys.stderr)
+    except Exception as e:
+        print(f"  ⚠ Slack notify failed: {e}", file=sys.stderr)
+
+
 def create_pr(fixes: list[dict]) -> None:
     slug      = re.sub(r"[^a-z0-9]+", "-", PIPELINE.lower())[:25].strip("-")
     short_sha = (HEAD_SHA or "unknown")[:8]
@@ -397,6 +433,9 @@ def create_pr(fixes: list[dict]) -> None:
         return
     pr_url = create.stdout.strip()
     print(f"  ✅ PR created: {pr_url}")
+
+    # Ping the human in Slack — GitHub won't, since the bot authored the PR.
+    slack_notify(pr_url, fixes)
 
     # Best-effort metadata — a missing label/reviewer must never orphan the PR.
     # Reviewer is opt-in via PR_REVIEWER env (must be a real repo collaborator).

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -102,6 +102,9 @@ jobs:
           HF_TOKEN:           ${{ secrets.HF_TOKEN }}
           GEMINI_API_KEY:     ${{ secrets.GEMINI_API_KEY }}
           GITHUB_TOKEN:       ${{ secrets.GITHUB_TOKEN }}
+          # Slack ping when a PR is opened — no webhook needed, bot token only.
+          SLACK_BOT_TOKEN:        ${{ secrets.SLACK_BOT_TOKEN }}
+          BUG_REPORTS_CHANNEL_ID: ${{ secrets.BUG_REPORTS_CHANNEL_ID }}
           FAILED_RUN_ID:      ${{ github.event.workflow_run.id }}
           FAILED_RUN_URL:     ${{ github.event.workflow_run.html_url }}
           PIPELINE:           ${{ github.event.workflow_run.name }}

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -103,7 +103,10 @@ jobs:
           GEMINI_API_KEY:     ${{ secrets.GEMINI_API_KEY }}
           GITHUB_TOKEN:       ${{ secrets.GITHUB_TOKEN }}
           # Slack ping when a PR is opened — no webhook needed, bot token only.
+          # PR-review pings go to the dedicated #ci-pr-review channel; the
+          # bug-reports channel stays the fallback if PR_REVIEW_CHANNEL_ID is unset.
           SLACK_BOT_TOKEN:        ${{ secrets.SLACK_BOT_TOKEN }}
+          PR_REVIEW_CHANNEL_ID:   ${{ secrets.PR_REVIEW_CHANNEL_ID }}
           BUG_REPORTS_CHANNEL_ID: ${{ secrets.BUG_REPORTS_CHANNEL_ID }}
           FAILED_RUN_ID:      ${{ github.event.workflow_run.id }}
           FAILED_RUN_URL:     ${{ github.event.workflow_run.html_url }}

--- a/auto-fix.agent.md
+++ b/auto-fix.agent.md
@@ -1,6 +1,6 @@
 ---
 name: auto-fix
-description: Use this agent when GitHub Actions CI runs have failed on PW_alexpavsky. The agent checks for new failures since the last run, downloads logs, identifies the root cause, patches test files, and opens a PR with alexpavsky as reviewer. Never touches application code or merges PRs. Can be run manually or is triggered automatically every 2 hours by a macOS LaunchAgent.
+description: Use this agent when GitHub Actions CI runs have failed on PW_alexpavsky. The agent checks for new failures since the last run, downloads logs, identifies the root cause, patches test files, and opens a PR (labelled `bug`) for human review. Never touches application code or merges PRs. Can be run manually or is triggered automatically every 2 hours by a macOS LaunchAgent.
 model: sonnet
 color: red
 tools:
@@ -19,7 +19,7 @@ Your job: find failed GitHub Actions runs → diagnose the root cause → fix th
 - **NEVER merge PRs** — only open them
 - **NEVER modify application code** — only test files (`*.spec.ts`, `*.spec.js`, `*_test.py`, `conftest.py`)
 - **NEVER add `waitForTimeout()`, `sleep()`, or arbitrary delays** — fix the root cause instead
-- **Always add `alexpavsky` as PR reviewer**
+- **Create the PR first, then add metadata** — a bad `--reviewer`/`--label` makes `gh pr create` exit non-zero *after* pushing, orphaning the branch. Apply label/reviewer as separate best-effort `gh pr edit` calls.
 - **If you cannot confidently identify a fix, skip that run and log why** — do not guess
 
 ---
@@ -121,7 +121,8 @@ Files changed: <list>"
 
 git push origin "$BRANCH"
 
-gh pr create \
+# Step 1: create the PR with ONLY flags that can't fail.
+PR_URL=$(gh pr create \
   --repo qa-apps/PW_alexpavsky \
   --title "fix: auto-fix <pipeline> (<short-sha>)" \
   --body "## 🤖 Auto-fix: <pipeline>
@@ -139,13 +140,16 @@ gh pr create \
 
 ---
 *Created by auto-fix agent. Review carefully before merging.*" \
-  --reviewer alexpavsky \
-  --label bug-fix \
   --head "$BRANCH" \
-  --base master
+  --base master)
+
+# Step 2: best-effort metadata. Failures here must NOT abort — the PR exists.
+gh pr edit "$PR_URL" --repo qa-apps/PW_alexpavsky --add-label bug || true
 ```
 
-If `--reviewer alexpavsky` fails, retry without `--reviewer`.
+Use the label `bug` (the repo has no `bug-fix` label). Do **not** request a
+reviewer: the only collaborator is the bot account `qa-apps`, which can't
+review its own PRs — you are notified because the repo is watched.
 
 ### Step 5 — Update state
 


### PR DESCRIPTION
## Summary
The auto-fix agent was pushing fix branches but failing to open PRs for them, because `gh pr create` exited non-zero **after** pushing whenever it hit invalid metadata:

- `--reviewer alexpavsky` → `alexpavsky` is not a repo collaborator (only `qa-apps` is, and it can't review its own PRs)
- `--label bug-fix` → that label doesn't exist (repo has `bug`)

The agent treated the non-zero exit as a total failure, so the branch was left orphaned with no PR — silently breaking the "every fix gets a PR for review" rule.

## Fix
- Create the PR with only flags that can't fail (title/body/head/base).
- Apply the `bug` label and an **optional** reviewer (`PR_REVIEWER` env) as best-effort `gh pr edit` calls that never abort the PR.
- Applied in both `.github/scripts/auto_fix_agent.py` (CI) and the local agent prompt `auto-fix.agent.md`.

Also fixed separately (local-only, not in repo): duplicate log lines in `~/.qaapps/auto_fix_local.py` (StreamHandler + launchd stdout redirect both wrote to the same file).

## Test plan
- [x] `python3 -m py_compile` passes on both scripts
- [x] Recovered the existing orphaned branch as PR #3
- [ ] Next real CI failure opens a PR cleanly with the `bug` label