### PR TITLE
feat(autofix): trigger on RAG eval failures + detailed agent reports

### DIFF
--- a/.github/scripts/auto_fix_agent.py
+++ b/.github/scripts/auto_fix_agent.py
@@ -51,8 +51,26 @@ SLACK_TOKEN   = os.environ.get("SLACK_BOT_TOKEN", "")
 SLACK_CHANNEL = (os.environ.get("PR_REVIEW_CHANNEL_ID", "")
                  or os.environ.get("BUG_REPORTS_CHANNEL_ID", ""))
 
+# Detailed Investigation / Fix / Resolution reports go to #qa-agent-reports.
+# Fall back to the PR-review/bug channel so a report is never silently lost.
+AGENT_REPORTS_CHANNEL = (os.environ.get("AGENT_REPORTS_CHANNEL_ID", "")
+                         or SLACK_CHANNEL)
+
+# Pipelines where we must NOT auto-patch code. RAG / eval-quality failures have
+# their root cause in the RAG app, the knowledge base, or the eval dataset —
+# none of which the agent is allowed to edit. For these we investigate, post a
+# detailed report, and open a tracking issue instead of a PR.
+REPORT_ONLY_KEYWORDS = ("ragas", "rag eval", "eval nightly", "giskard")
+
 MAX_LOG_CHARS  = 18000
 MAX_FILE_CHARS = 12000
+
+
+def is_report_only(pipeline: str) -> bool:
+    """True for RAG/eval pipelines that should be investigated + reported but
+    never auto-patched."""
+    p = pipeline.lower()
+    return any(k in p for k in REPORT_ONLY_KEYWORDS)
 
 
 # ---------------------------------------------------------------------------
@@ -170,6 +188,42 @@ def read_files(paths: list[str]) -> str:
                 break
         except Exception:
             pass
+    return "\n\n".join(parts)
+
+
+def gather_eval_context() -> str:
+    """For RAG/eval pipelines: collect the human-readable report + machine
+    summary so the LLM can investigate which questions failed and why. Reads
+    both the in-repo eval/results/ and any artifact dirs the workflow extracted
+    from the failed run."""
+    patterns = [
+        "eval/results/report.md",
+        "eval/results/summary.json",
+        "eval/results/giskard_rag.json",
+        "eval/results/giskard_scan.json",
+        "**/report.md",
+        "**/summary.json",
+        "**/giskard_rag.json",
+        "**/giskard_scan.json",
+    ]
+    seen: set[str] = set()
+    parts: list[str] = []
+    total = 0
+    for pat in patterns:
+        for p in sorted(Path(".").glob(pat)):
+            sp = str(p)
+            if sp in seen or not p.is_file():
+                continue
+            seen.add(sp)
+            try:
+                text = p.read_text(errors="replace")
+            except Exception:
+                continue
+            chunk = f"### {sp}\n{text[:4000]}"
+            parts.append(chunk)
+            total += len(chunk)
+            if total > MAX_FILE_CHARS:
+                return "\n\n".join(parts)
     return "\n\n".join(parts)
 
 
@@ -300,6 +354,64 @@ def call_llm(logs: str, files: str) -> tuple[list[dict], str]:
     return [], ""
 
 
+REPORT_SYSTEM_PROMPT = """You are a senior QA / LLM-evaluation engineer triaging a failed CI run.
+Write a concise incident report grounded in concrete evidence from the logs
+(test names, metrics, thresholds, error messages). Never invent details — if
+the logs are inconclusive, say so.
+
+Return ONLY a JSON object (no markdown fence, no prose around it) with keys:
+- "investigation": 2-4 sentences. What failed and the most likely root cause,
+  citing specific evidence.
+- "fix": 2-4 sentences. For test-code failures, the concrete code change that
+  resolves it. For RAG / eval-quality failures, the concrete fix you recommend
+  (which dataset/threshold/file or which RAG-app behaviour) — note that test
+  code cannot fix a genuine answer-quality regression.
+- "severity": one of "low", "medium", "high"."""
+
+
+def investigate(logs: str, context: str) -> dict:
+    """Ask the LLM for a structured Investigation/Fix narrative. Returns a dict
+    with keys investigation, fix, severity. Never raises — returns {} on fail."""
+    prompt = f"""Pipeline: {PIPELINE}
+Failed run: {RUN_URL}
+
+## CI failure logs (truncated):
+{logs}
+
+## Additional context (test files / eval reports):
+{context}
+
+Produce the JSON incident report described in the system prompt."""
+    try:
+        result = llm_client.chat(
+            messages=[{"role": "user", "content": prompt}],
+            system=REPORT_SYSTEM_PROMPT,
+            max_tokens=1024,
+            temperature=0.2,
+            timeout=90,
+        )
+    except Exception as e:
+        print(f"  ⚠ investigate() LLM error: {e}", file=sys.stderr)
+        return {}
+    content = (result.get("content") or "").strip()
+    if not content:
+        return {}
+    cleaned = re.sub(r"^```[a-z]*\n?", "", content).rstrip("` \n")
+    # Some models wrap the JSON in prose — grab the first {...} block.
+    m = re.search(r"\{.*\}", cleaned, re.DOTALL)
+    if m:
+        cleaned = m.group(0)
+    try:
+        data = json.loads(cleaned)
+        if isinstance(data, dict):
+            return data
+    except json.JSONDecodeError:
+        print("  ⚠ investigate() returned non-JSON; using raw text",
+              file=sys.stderr)
+        return {"investigation": content[:600], "fix": "", "severity": "medium"}
+    return {}
+
+
 # ---------------------------------------------------------------------------
 # Apply fixes
 # ---------------------------------------------------------------------------
@@ -349,18 +461,12 @@ def git(*args: str) -> str:
     return result.stdout.strip()
 
 
-def slack_notify(pr_url: str, fixes: list[dict]) -> None:
-    """Best-effort Slack ping that a PR needs review. Uses the bot token +
-    channel that already exist as repo secrets — no webhook required.
-    GitHub never emails about PRs the bot's own account authored, so this is
-    how the human actually finds out. Never raises."""
-    if not SLACK_TOKEN or not SLACK_CHANNEL:
-        print("  (slack notify skipped — SLACK_BOT_TOKEN/BUG_REPORTS_CHANNEL_ID not set)")
-        return
-    changed = ", ".join(sorted({f["file_path"] for f in fixes})) or "test files"
-    text = (f":robot_face: *Auto-fix PR ready for review* — {PIPELINE}\n"
-            f"Files: {changed}\n{pr_url}")
-    payload = json.dumps({"channel": SLACK_CHANNEL, "text": text}).encode()
+def slack_post(channel: str, text: str, label: str = "Slack") -> bool:
+    """Best-effort chat.postMessage with the bot token. Never raises."""
+    if not SLACK_TOKEN or not channel:
+        print(f"  ({label} skipped — SLACK_BOT_TOKEN/channel not set)")
+        return False
+    payload = json.dumps({"channel": channel, "text": text}).encode()
     req = urllib.request.Request(
         "https://slack.com/api/chat.postMessage",
         data=payload,
@@ -373,14 +479,96 @@ def slack_notify(pr_url: str, fixes: list[dict]) -> None:
         with urllib.request.urlopen(req, timeout=15) as r:
             resp = json.loads(r.read())
         if resp.get("ok"):
-            print("  💬 Slack notification sent")
-        else:
-            print(f"  ⚠ Slack notify error: {resp.get('error')}", file=sys.stderr)
+            print(f"  💬 {label} sent")
+            return True
+        print(f"  ⚠ {label} error: {resp.get('error')}", file=sys.stderr)
     except Exception as e:
-        print(f"  ⚠ Slack notify failed: {e}", file=sys.stderr)
+        print(f"  ⚠ {label} failed: {e}", file=sys.stderr)
+    return False
 
 
-def create_pr(fixes: list[dict]) -> None:
+def slack_notify(pr_url: str, fixes: list[dict]) -> None:
+    """Short Slack ping to the PR-review channel that a PR needs review.
+    GitHub never emails about PRs the bot's own account authored, so this is
+    how the human actually finds out."""
+    changed = ", ".join(sorted({f["file_path"] for f in fixes})) or "test files"
+    text = (f":robot_face: *Auto-fix PR ready for review* — {PIPELINE}\n"
+            f"Files: {changed}\n{pr_url}")
+    slack_post(SLACK_CHANNEL, text, label="Slack PR notify")
+
+
+_SEVERITY_EMOJI = {"high": ":rotating_light:", "medium": ":warning:",
+                   "low": ":information_source:"}
+
+
+def post_agent_report(report: dict, resolution: str) -> None:
+    """Post the detailed Investigation / Fix / Resolution report to
+    #qa-agent-reports. `report` comes from investigate(); `resolution` is set
+    by the caller based on what actually happened (PR opened, issue opened, or
+    no safe fix). Best-effort — never raises."""
+    severity = (report.get("severity") or "medium").lower()
+    emoji = _SEVERITY_EMOJI.get(severity, ":warning:")
+    investigation = report.get("investigation") or "_(no analysis produced)_"
+    fix = report.get("fix") or "_(no fix proposed)_"
+    text = (
+        f"{emoji} *Agent incident report — {PIPELINE}*  _(severity: {severity})_\n"
+        f"*Failed run:* {RUN_URL}\n\n"
+        f"*:mag: Investigation*\n{investigation}\n\n"
+        f"*:wrench: Fix*\n{fix}\n\n"
+        f"*:white_check_mark: Resolution*\n{resolution}"
+    )
+    slack_post(AGENT_REPORTS_CHANNEL, text, label="Agent report")
+
+
+def open_tracking_issue(report: dict) -> str:
+    """Open a GitHub issue capturing the investigation + recommended fix for a
+    failure the agent must not auto-patch (RAG/eval) or couldn't fix safely.
+    Returns the issue URL, or "" on failure. Best-effort."""
+    severity = (report.get("severity") or "medium").lower()
+    investigation = report.get("investigation") or "(no analysis produced)"
+    fix = report.get("fix") or "(no fix proposed)"
+    title = f"[auto-triage] {PIPELINE} failure — needs human review"
+    body = f"""## 🤖 Agent triage report
+
+**Failed CI run:** {RUN_URL}
+**Head commit:** `{HEAD_SHA}`
+**Severity:** {severity}
+
+### 🔍 Investigation
+{investigation}
+
+### 🔧 Recommended fix
+{fix}
+
+---
+*Opened automatically by the auto-fix agent. This failure was not auto-patched
+(RAG/eval-quality root causes live in the app, knowledge base, or dataset, which
+the agent must not edit, or no confident test-code fix was found). A human should
+review and decide on the fix.*
+"""
+    create = subprocess.run(
+        ["gh", "issue", "create", "--title", title, "--body", body],
+        capture_output=True, text=True,
+    )
+    if create.returncode != 0:
+        print(f"  ⚠ issue creation failed: {create.stderr.strip()}",
+              file=sys.stderr)
+        return ""
+    issue_url = create.stdout.strip()
+    print(f"  ✅ tracking issue created: {issue_url}")
+    # Best-effort label — a missing label must never fail the run.
+    lbl = subprocess.run(
+        ["gh", "issue", "edit", issue_url, "--add-label", "bug"],
+        capture_output=True, text=True,
+    )
+    if lbl.returncode != 0:
+        print(f"  (issue label not applied: {lbl.stderr.strip()})",
+              file=sys.stderr)
+    return issue_url
+
+
+def create_pr(fixes: list[dict]) -> str:
+    """Push the fix branch and open a PR. Returns the PR URL, or "" on failure."""
     slug      = re.sub(r"[^a-z0-9]+", "-", PIPELINE.lower())[:25].strip("-")
     short_sha = (HEAD_SHA or "unknown")[:8]
     branch    = f"fix/{slug}-{short_sha}"
@@ -433,7 +621,7 @@ def create_pr(fixes: list[dict]) -> None:
     )
     if create.returncode != 0:
         print(f"  ⚠ PR creation failed: {create.stderr.strip()}", file=sys.stderr)
-        return
+        return ""
     pr_url = create.stdout.strip()
     print(f"  ✅ PR created: {pr_url}")
 
@@ -456,6 +644,8 @@ def create_pr(fixes: list[dict]) -> None:
         )
         if rev.returncode != 0:
             print(f"  (reviewer not added: {rev.stderr.strip()})", file=sys.stderr)
+
+    return pr_url
 
 
 # ---------------------------------------------------------------------------
@@ -495,11 +685,44 @@ def main() -> None:
                 pass
 
     if not logs:
-        print("  No logs available — cannot fix. Exiting.")
+        print("  No logs available — cannot triage. Exiting.")
         sys.exit(0)
 
     print(f"  Got {len(logs)} chars of logs")
 
+    # -----------------------------------------------------------------
+    # REPORT-ONLY path: RAG / eval-quality pipelines. We never auto-patch
+    # (the root cause lives in the app / KB / dataset, which the agent must
+    # not edit). Instead: investigate, open a tracking issue, post a detailed
+    # Investigation / Fix / Resolution report to #qa-agent-reports.
+    # -----------------------------------------------------------------
+    if is_report_only(PIPELINE):
+        print(f"\n[2] Report-only pipeline ({PIPELINE}) — investigating...")
+        context = gather_eval_context()
+        report = investigate(logs, context)
+        if not report:
+            report = {"investigation": "Automated analysis was inconclusive — "
+                                       "see the failed run logs.",
+                      "fix": "", "severity": "medium"}
+        print("\n[3] Opening tracking issue...")
+        issue_url = open_tracking_issue(report)
+        if issue_url:
+            resolution = (f"No safe auto-fix — RAG/eval-quality regressions need "
+                          f"a human decision. Opened tracking issue for review: "
+                          f"{issue_url}")
+        else:
+            resolution = ("No safe auto-fix — RAG/eval-quality regressions need a "
+                          "human decision. (Tracking-issue creation failed; see "
+                          "the failed run logs.)")
+        print("\n[4] Posting detailed report to #qa-agent-reports...")
+        post_agent_report(report, resolution)
+        print("\nDone.")
+        return
+
+    # -----------------------------------------------------------------
+    # PATCH path: test-code pipelines (Playwright, LLM-judge). Try to fix,
+    # open a PR, and always post a detailed report (even when no fix is found).
+    # -----------------------------------------------------------------
     # 2. Find failing files
     print("\n[2] Identifying failing test files...")
     failing = find_failing_files(logs)
@@ -509,26 +732,49 @@ def main() -> None:
     # 3. Call LLM (rotates through all configured providers)
     print("\n[3] Calling LLM for fix analysis...")
     tool_uses, provider = call_llm(logs, file_content)
-    if not tool_uses:
-        print("  No LLM produced a usable fix — exiting cleanly.")
-        sys.exit(0)
-    print(f"  Fix author: {provider}")
+    print(f"  Fix author: {provider or '(none)'}")
 
     # 4. Apply fixes
-    print("\n[4] Applying fixes...")
-    applied = apply_fixes(tool_uses)
-    if not applied:
-        print("  No fixes could be applied safely.")
-        sys.exit(0)
+    applied: list[dict] = []
+    if tool_uses:
+        print("\n[4] Applying fixes...")
+        applied = apply_fixes(tool_uses)
 
-    # 5. Check for actual changes
-    if not git("diff", "--name-only", "HEAD"):
-        print("  No file changes after applying fixes.")
-        sys.exit(0)
+    has_changes = bool(applied) and bool(git("diff", "--name-only", "HEAD"))
 
-    # 6. Create PR
-    print("\n[5] Creating PR...")
-    create_pr(applied)
+    # 5. Open a PR if we have real changes
+    pr_url = ""
+    if has_changes:
+        print("\n[5] Creating PR...")
+        pr_url = create_pr(applied)
+
+    # 6. Always post a detailed Investigation / Fix / Resolution report.
+    print("\n[6] Building detailed report...")
+    report = investigate(logs, file_content)
+    if not report:
+        report = {"investigation": "Automated analysis was inconclusive — "
+                                   "see the failed run logs.",
+                  "fix": "", "severity": "medium"}
+    # Overlay the concrete fixes we actually applied, so the report's "Fix"
+    # section reflects reality rather than only the LLM's narrative.
+    if applied:
+        applied_lines = "\n".join(
+            f"• `{f['file_path']}` — {f['reason']}" for f in applied)
+        report["fix"] = (report.get("fix", "").strip() + "\n\n*Applied changes:*\n"
+                         + applied_lines).strip()
+
+    if pr_url:
+        resolution = f"Auto-fix PR opened for your review (do not auto-merge): {pr_url}"
+    elif applied and not has_changes:
+        resolution = "Proposed edits produced no net change — needs human review."
+    else:
+        # No confident fix — open a tracking issue so it isn't lost.
+        issue_url = open_tracking_issue(report)
+        resolution = (f"No confident auto-fix found. Opened tracking issue: {issue_url}"
+                      if issue_url else
+                      "No confident auto-fix found — needs human review (see logs).")
+
+    post_agent_report(report, resolution)
     print("\nDone.")
 
 

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -68,7 +68,7 @@ jobs:
             });
             const fs = require('fs');
             for (const artifact of artifacts.data.artifacts) {
-              const names = ['test-results', 'playwright-report', 'eval-results'];
+              const names = ['test-results', 'playwright-report', 'eval-results', 'eval-report'];
               if (names.some(n => artifact.name.includes(n))) {
                 const zip = await github.rest.actions.downloadArtifact({
                   owner: context.repo.owner,
@@ -108,6 +108,9 @@ jobs:
           SLACK_BOT_TOKEN:        ${{ secrets.SLACK_BOT_TOKEN }}
           PR_REVIEW_CHANNEL_ID:   ${{ secrets.PR_REVIEW_CHANNEL_ID }}
           BUG_REPORTS_CHANNEL_ID: ${{ secrets.BUG_REPORTS_CHANNEL_ID }}
+          # Detailed Investigation / Fix / Resolution reports land here
+          # (#qa-agent-reports). Falls back to the PR-review channel if unset.
+          AGENT_REPORTS_CHANNEL_ID: ${{ secrets.AGENT_REPORTS_CHANNEL_ID }}
           FAILED_RUN_ID:      ${{ github.event.workflow_run.id }}
           FAILED_RUN_URL:     ${{ github.event.workflow_run.html_url }}
           PIPELINE:           ${{ github.event.workflow_run.name }}

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ eval/results/
 # GitHub Pages eval site build output — only used by CI
 gh-pages-site/
 gh-pages-existing/
+
+# Local screenshot artifacts from MCP-driven manual verification
+screenshots/

--- a/eval/ragas_eval.py
+++ b/eval/ragas_eval.py
@@ -53,6 +53,11 @@ RAG_API_URL = os.environ.get("RAG_API_URL", "http://localhost:8001").rstrip("/")
 MIN_FAITHFULNESS = float(os.environ.get("MIN_FAITHFULNESS", "0.65"))
 MIN_RELEVANCY = float(os.environ.get("MIN_RELEVANCY", "0.55"))
 MAX_QUESTIONS = int(os.environ.get("MAX_QUESTIONS", "0"))  # 0 = all
+# How many individual question failures are tolerated before the run is marked
+# failed (and the auto-fix agent is allowed to trigger). Default 0 = any single
+# failed question fails the build, so "even RAG" failures get investigated.
+# Set ALLOWED_FAILURES=-1 to fall back to average-only gating (legacy behaviour).
+ALLOWED_FAILURES = int(os.environ.get("ALLOWED_FAILURES", "0"))
 OUTPUT_PATH = Path(os.environ.get("OUTPUT_PATH", str(RESULTS_DIR / "report.md")))
 
 REQUEST_DELAY_SEC = float(os.environ.get("REQUEST_DELAY_SEC", "1.0"))
@@ -456,12 +461,21 @@ def main() -> int:
         json.dumps(summary_json, indent=2), encoding="utf-8"
     )
 
-    # Exit code: pass/fail based on thresholds
+    # Exit code: pass/fail based on thresholds.
+    # Previously this only considered the *average* faithfulness/relevancy, so a
+    # run with individual question failures (e.g. 24/27 passed) still exited 0,
+    # GitHub marked it "success", and the auto-fix gate (conclusion == failure)
+    # never fired. We now also fail when too many individual questions fail.
+    failed_count = summary_json["failed"]
     failed_checks: list[str] = []
     if avg_f < MIN_FAITHFULNESS:
-        failed_checks.append(f"faithfulness {avg_f:.3f} < {MIN_FAITHFULNESS}")
+        failed_checks.append(f"avg faithfulness {avg_f:.3f} < {MIN_FAITHFULNESS}")
     if avg_r < MIN_RELEVANCY:
-        failed_checks.append(f"relevancy {avg_r:.3f} < {MIN_RELEVANCY}")
+        failed_checks.append(f"avg relevancy {avg_r:.3f} < {MIN_RELEVANCY}")
+    if ALLOWED_FAILURES >= 0 and failed_count > ALLOWED_FAILURES:
+        failed_checks.append(
+            f"{failed_count} question(s) failed "
+            f"(> {ALLOWED_FAILURES} allowed)")
 
     if failed_checks:
         log("FAIL: " + "; ".join(failed_checks))

--- a/tests/feed-api.spec.ts
+++ b/tests/feed-api.spec.ts
@@ -86,10 +86,10 @@ test.describe('Live Feed + Article API', () => {
   });
 });
 
-test.describe('Article modal — iframe load (E2E)', () => {
-  test('opening a feed article must not show a 4xx error page inside the iframe', async ({ page }) => {
+test.describe('Article modal — reader-area load (E2E)', () => {
+  test('opening a feed article must not show a 4xx error page in the modal', async ({ page }) => {
     // Record any /api/article-* response so we can fail fast on a 4xx — but
-    // the iframe-content assertion below is the real safety net.
+    // the reader-content assertion below is the real safety net.
     const apiResponses: { url: string; status: number }[] = [];
     page.on('response', (resp) => {
       const u = resp.url();
@@ -106,23 +106,24 @@ test.describe('Article modal — iframe load (E2E)', () => {
     const modal = page.locator('#article-modal-overlay, .article-modal').first();
     await expect(modal).toBeVisible({ timeout: 5_000 });
 
-    // The iframe src is set inside loadIframeView(); give it time to load.
-    const iframe = page.locator('#article-modal-iframe');
-    await expect(iframe).toBeVisible({ timeout: 5_000 });
-    await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => undefined);
+    // Production now renders article content (or its fallback) into the
+    // #article-modal-reader div; the iframe is hidden. See production
+    // script.js:944-951 — the .loaded class is added once content/fallback
+    // is in place.
+    const reader = page.locator('#article-modal-reader');
+    await expect(reader).toHaveClass(/loaded/, { timeout: 15_000 });
 
-    // Real check: pull HTML from inside the iframe and assert it isn't the
-    // BaseHTTPRequestHandler 404 page (which is exactly what users saw in
-    // production before this fix).
-    const frame = page.frameLocator('#article-modal-iframe');
-    const bodyText = await frame.locator('body').textContent().catch(() => '');
+    // Real check: assert the reader body isn't the BaseHTTPRequestHandler
+    // 404 page (which is exactly what users saw in production before the
+    // article-proxy fix).
+    const bodyText = await reader.innerText({ timeout: 5_000 }).catch(() => '');
     const body = (bodyText || '').slice(0, 4000);
-    expect(body, 'iframe must not render the http.server 404 error page').not.toContain('Error code: 404');
-    expect(body, 'iframe must not render the http.server file-not-found error').not.toContain('File not found');
+    expect(body, 'reader must not render the http.server 404 error page').not.toContain('Error code: 404');
+    expect(body, 'reader must not render the http.server file-not-found error').not.toContain('File not found');
 
     // If any of our endpoints did respond, none should be 4xx/5xx.
     for (const r of apiResponses) {
-      expect(r.status, `iframe loaded ${r.url} with status ${r.status}`).toBeLessThan(400);
+      expect(r.status, `article endpoint ${r.url} returned ${r.status}`).toBeLessThan(400);
     }
   });
 });

--- a/tests/feed.spec.ts
+++ b/tests/feed.spec.ts
@@ -120,5 +120,42 @@ test.describe('Live feed @upstream', () => {
       await homePage.openFeedArticle(0);
       expect(await homePage.articleModalLinks.count()).toBeGreaterThan(0);
     });
+
+    test('iframe must render real article content, not the blocked/fallback screen', async ({ homePage, page }) => {
+      await homePage.openFeedArticle(0);
+      const iframe = page.locator('#article-modal-iframe');
+      await expect(iframe).toHaveClass(/loaded/, { timeout: 15_000 });
+
+      const body = await page.frameLocator('#article-modal-iframe')
+        .locator('body').innerText({ timeout: 10_000 });
+
+      expect(body, 'iframe shows blocked/fallback page').not.toMatch(
+        /This content is blocked|Article preview unavailable|preview request failed|took too long/i
+      );
+      expect(body.replace(/\s+/g, ' ').trim().length, 'iframe body empty').toBeGreaterThan(200);
+    });
+
+    test('majority of feed articles render real content', async ({ homePage, page }) => {
+      const total = Math.min(await homePage.feedCards.count(), 5);
+      const broken: string[] = [];
+      for (let i = 0; i < total; i++) {
+        await homePage.openFeedArticle(i);
+        const iframe = page.locator('#article-modal-iframe');
+        let body = '';
+        try {
+          await expect(iframe).toHaveClass(/loaded/, { timeout: 15_000 });
+          body = await page.frameLocator('#article-modal-iframe')
+            .locator('body').innerText({ timeout: 8_000 });
+        } catch (e) {
+          body = String(e);
+        }
+        if (/blocked|unavailable|failed|took too long/i.test(body) || body.trim().length < 200) {
+          const title = (await homePage.articleModalTitle.innerText().catch(() => '?')).slice(0, 60);
+          broken.push(`#${i}: ${title}`);
+        }
+        await homePage.closeArticleModal();
+      }
+      expect(broken, `broken articles:\n${broken.join('\n')}`).toEqual([]);
+    });
   });
 });

--- a/tests/feed.spec.ts
+++ b/tests/feed.spec.ts
@@ -121,35 +121,37 @@ test.describe('Live feed @upstream', () => {
       expect(await homePage.articleModalLinks.count()).toBeGreaterThan(0);
     });
 
-    test('iframe must render real article content, not the blocked/fallback screen', async ({ homePage, page }) => {
+    // Production renders article content (or its fallback) into the
+    // #article-modal-reader div; the iframe is hidden. See production
+    // script.js:944-951.
+
+    test('reader must render real article content, not the blocked/fallback screen', async ({ homePage, page }) => {
       await homePage.openFeedArticle(0);
-      const iframe = page.locator('#article-modal-iframe');
-      await expect(iframe).toHaveClass(/loaded/, { timeout: 15_000 });
+      const reader = page.locator('#article-modal-reader');
+      await expect(reader).toHaveClass(/loaded/, { timeout: 15_000 });
 
-      const body = await page.frameLocator('#article-modal-iframe')
-        .locator('body').innerText({ timeout: 10_000 });
+      const body = await reader.innerText({ timeout: 10_000 });
 
-      expect(body, 'iframe shows blocked/fallback page').not.toMatch(
-        /This content is blocked|Article preview unavailable|preview request failed|took too long/i
+      expect(body, 'reader shows blocked/fallback page').not.toMatch(
+        /preview is unavailable|RSS preview|publisher blocks|took too long/i,
       );
-      expect(body.replace(/\s+/g, ' ').trim().length, 'iframe body empty').toBeGreaterThan(200);
+      expect(body.replace(/\s+/g, ' ').trim().length, 'reader body empty').toBeGreaterThan(200);
     });
 
     test('majority of feed articles render real content', async ({ homePage, page }) => {
       const total = Math.min(await homePage.feedCards.count(), 5);
       const broken: string[] = [];
+      const reader = page.locator('#article-modal-reader');
       for (let i = 0; i < total; i++) {
         await homePage.openFeedArticle(i);
-        const iframe = page.locator('#article-modal-iframe');
         let body = '';
         try {
-          await expect(iframe).toHaveClass(/loaded/, { timeout: 15_000 });
-          body = await page.frameLocator('#article-modal-iframe')
-            .locator('body').innerText({ timeout: 8_000 });
+          await expect(reader).toHaveClass(/loaded/, { timeout: 15_000 });
+          body = await reader.innerText({ timeout: 8_000 });
         } catch (e) {
           body = String(e);
         }
-        if (/blocked|unavailable|failed|took too long/i.test(body) || body.trim().length < 200) {
+        if (/preview is unavailable|RSS preview|publisher blocks|took too long/i.test(body) || body.trim().length < 200) {
           const title = (await homePage.articleModalTitle.innerText().catch(() => '?')).slice(0, 60);
           broken.push(`#${i}: ${title}`);
         }

--- a/tests/networkInterceptionMocking.spec.ts
+++ b/tests/networkInterceptionMocking.spec.ts
@@ -1,0 +1,363 @@
+/**
+ * networkInterceptionMocking.spec.ts
+ *
+ * Demonstrates how Playwright's page.route() is used to intercept and
+ * mock backend responses, so we can verify how the frontend behaves
+ * under unhappy conditions (5xx, 4xx, network abort, slow response)
+ * without actually breaking the real backend.
+ *
+ * Every assertion is anchored to a REAL UI string from
+ * alexpavsky/script.js — no invented text. Line references are listed
+ * in the comments so the spec stays grep-friendly when the source
+ * changes.
+ *
+ * Sources:
+ *  - newsletter:          script.js:1719-1747  (#newsletter-msg.error/success)
+ *  - chatbot:             script.js:3540-3625  (graceful reply / getFallbackReply)
+ *  - feed:                script.js:728-772    (silent fallback to FEED_FALLBACK_ARTICLES)
+ *  - article-page reader: script.js:888-988    (#article-modal-reader fallback texts)
+ */
+
+import { test, expect } from '../utils/fixtures';
+
+test.describe('Network interception & mocking', () => {
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 1. Newsletter form — one mock per backend behavior
+  // ───────────────────────────────────────────────────────────────────────────
+  test.describe('Newsletter — /api/subscribe', () => {
+    test('500 from server → shows server error text in newsletter message', async ({ page, homePage }) => {
+      // IMPORTANT: route() must be set BEFORE goto() so even preflight
+      // requests are intercepted.
+      await page.route('**/api/subscribe', (route) =>
+        route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Server is on fire' }),
+        }),
+      );
+
+      await homePage.goto();
+      await homePage.subscribe('user@example.com');
+
+      // script.js:1757 — when res.ok is false and data.error is present,
+      // the frontend echoes data.error verbatim.
+      await expect(homePage.newsletterError).toBeVisible();
+      await expect(homePage.newsletterError).toContainText('Server is on fire');
+    });
+
+    test('500 without error field → default text "Something went wrong."', async ({ page, homePage }) => {
+      await page.route('**/api/subscribe', (route) =>
+        route.fulfill({ status: 500, contentType: 'application/json', body: '{}' }),
+      );
+
+      await homePage.goto();
+      await homePage.subscribe('user@example.com');
+
+      await expect(homePage.newsletterError).toContainText('Something went wrong');
+    });
+
+    test('404 not found → still routed through the error branch', async ({ page, homePage }) => {
+      await page.route('**/api/subscribe', (route) =>
+        route.fulfill({
+          status: 404,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Endpoint missing' }),
+        }),
+      );
+
+      await homePage.goto();
+      await homePage.subscribe('user@example.com');
+
+      await expect(homePage.newsletterError).toContainText('Endpoint missing');
+    });
+
+    test('network abort → "Network error. Try again."', async ({ page, homePage }) => {
+      // route.abort() raises a browser-level network failure that is
+      // caught by the fetch catch block.
+      await page.route('**/api/subscribe', (route) => route.abort('failed'));
+
+      await homePage.goto();
+      await homePage.subscribe('user@example.com');
+
+      // script.js:1761
+      await expect(homePage.newsletterError).toContainText('Network error');
+    });
+
+    test('200 success → success message', async ({ page, homePage }) => {
+      await page.route('**/api/subscribe', (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ message: 'Subscribed!' }),
+        }),
+      );
+
+      await homePage.goto();
+      await homePage.subscribe('user@example.com');
+
+      await expect(homePage.newsletterSuccess).toBeVisible();
+      await expect(homePage.newsletterSuccess).toContainText('Subscribed');
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 2. Live Feed — mock /api/feed with our own articles
+  // ───────────────────────────────────────────────────────────────────────────
+  // Note: tests covering "500 from /api/feed → FEED_FALLBACK_ARTICLES must
+  // render" are intentionally NOT included here. The current production
+  // FEED_FALLBACK_ARTICLES list has stale dates (March 2026) and the
+  // isRecentFeedArticle filter (script.js:511) drops all of them, leaving
+  // the grid empty on /api/feed failure. That is a real site bug tracked
+  // separately, not the subject of this spec.
+  test.describe('Live Feed — /api/feed', () => {
+    test('mock /api/feed with two custom articles → they render in the grid', async ({ page, homePage }) => {
+      const today = new Date().toISOString();
+      // Response shape contract (see script.js:751): { articles: [...] }.
+      // Article fields match what the RSS normalizer on the backend emits.
+      const fake = {
+        articles: [
+          {
+            title: 'MOCKED ARTICLE ONE',
+            description: 'Fully synthetic article for assertion.',
+            link: 'https://example.com/one',
+            source: 'Test Source',
+            category: 'qa',
+            date: today,
+            image: '',
+          },
+          {
+            title: 'MOCKED ARTICLE TWO',
+            description: 'Second one.',
+            link: 'https://example.com/two',
+            source: 'Test Source',
+            category: 'ai',
+            date: today,
+            image: '',
+          },
+        ],
+      };
+      await page.route('**/api/feed**', (route) =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(fake) }),
+      );
+
+      await homePage.goto();
+      await expect(homePage.feedCards.first()).toBeVisible({ timeout: 25_000 });
+      // .first() because the title also appears in the ticker (see
+      // updateTicker in script.js) — one match is enough.
+      await expect(page.locator('.feed-card', { hasText: 'MOCKED ARTICLE ONE' }).first()).toBeVisible();
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 3. Article modal — /api/article-page failures and slow responses
+  // ───────────────────────────────────────────────────────────────────────────
+  test.describe('Article modal — /api/article-page', () => {
+    test.beforeEach(async ({ homePage }) => {
+      await homePage.goto();
+      await expect(homePage.feedCards.first()).toBeVisible({ timeout: 25_000 });
+    });
+
+    // On production, article content (or its fallback) is rendered into
+    // the #article-modal-reader div; the iframe is hidden. See
+    // production script.js:944-951.
+
+    test('5xx → reader shows EXACT string "Full reader preview is unavailable..."', async ({ page, homePage }) => {
+      await page.route('**/api/article-page**', (route) =>
+        route.fulfill({ status: 500, contentType: 'text/html', body: '<!doctype html><html><body>boom</body></html>' }),
+      );
+
+      await homePage.openFeedArticle(0);
+      const reader = page.locator('#article-modal-reader');
+      await expect(reader).toHaveClass(/loaded/, { timeout: 15_000 });
+      // Exact string from production script.js:981
+      await expect(reader).toContainText(
+        'Full reader preview is unavailable for this publisher. Showing the RSS preview.',
+      );
+    });
+
+    test('slow response > 9s → reader shows EXACT string "...took too long..."', async ({ page, homePage }) => {
+      // Delay the response by 12 seconds — longer than the
+      // client-side iframeLoadTimer (9000 ms).
+      await page.route('**/api/article-page**', async (route) => {
+        await new Promise((r) => setTimeout(r, 12_000));
+        await route.fulfill({ status: 200, contentType: 'text/html', body: '<html><body>late</body></html>' });
+      });
+
+      await homePage.openFeedArticle(0);
+      const reader = page.locator('#article-modal-reader');
+      await expect(reader).toHaveClass(/loaded/, { timeout: 20_000 });
+      // Exact string from production script.js:983
+      await expect(reader).toContainText(
+        'Full reader preview took too long. Showing the RSS preview.',
+      );
+    });
+
+    test('200 but body marked "Article preview unavailable" → "publisher blocks..." fallback', async ({ page, homePage }) => {
+      // Per script.js:974-976, if the HTML body contains
+      // "Article preview unavailable" or "We couldn't fetch this
+      // article", the frontend throws "source blocked" and shows the
+      // third fallback branch (script.js:985).
+      await page.route('**/api/article-page**', (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'text/html',
+          body: '<html><body><h2>Article preview unavailable</h2><p>The source blocked us.</p></body></html>',
+        }),
+      );
+
+      await homePage.openFeedArticle(0);
+      const reader = page.locator('#article-modal-reader');
+      await expect(reader).toHaveClass(/loaded/, { timeout: 15_000 });
+      await expect(reader).toContainText(
+        'This publisher blocks embedded reader previews. Showing the RSS preview.',
+      );
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 4. Chatbot — graceful reply, fallback by topic, and exact server reply
+  // ───────────────────────────────────────────────────────────────────────────
+  test.describe('Chatbot — /api/chat', () => {
+    test('500 without graceful reply on "hello" → EXACT greeting fallback', async ({ page, chatbotPage }) => {
+      await page.route('**/api/chat', (route) =>
+        route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ error: 'down' }) }),
+      );
+
+      await chatbotPage.openAndConsent();
+      await chatbotPage.sendMessage('hello');
+
+      // getFallbackReply (script.js:3611) is deterministic: for the
+      // /^(hi|hello)/ branch it ALWAYS returns this exact string.
+      await expect(chatbotPage.finishedAiMessage).toContainText(
+        'Hey there! Ask me anything — AI testing, coding, science, history, or just chat.',
+        { timeout: 20_000 },
+      );
+    });
+
+    test('500 on "playwright" → EXACT playwright fallback', async ({ page, chatbotPage }) => {
+      // Different branch of getFallbackReply: it picks a reply by regex
+      // against the user message → different text per topic.
+      await page.route('**/api/chat', (route) =>
+        route.fulfill({ status: 500, contentType: 'application/json', body: '{}' }),
+      );
+
+      await chatbotPage.openAndConsent();
+      await chatbotPage.sendMessage('Tell me about playwright');
+
+      await expect(chatbotPage.finishedAiMessage).toContainText(
+        'Playwright is excellent for E2E testing',
+        { timeout: 20_000 },
+      );
+    });
+
+    test('200 with custom reply → UI prints EXACTLY the server reply', async ({ page, chatbotPage }) => {
+      // Proves the frontend prints exactly what the server sent — no
+      // trimming, no translation, no substitution. Mock with a unique
+      // marker string.
+      const marker = 'MOCK_SERVER_REPLY_42_unique_marker_string';
+      await page.route('**/api/chat', (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ reply: marker }),
+        }),
+      );
+
+      await chatbotPage.openAndConsent();
+      await chatbotPage.sendMessage('anything');
+
+      await expect(chatbotPage.finishedAiMessage).toContainText(marker, { timeout: 15_000 });
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 5. HTTP error matrix — sweep across error codes per endpoint
+  // ───────────────────────────────────────────────────────────────────────────
+  // Systematically run 401 / 403 / 404 / 502 / 503 against three
+  // endpoints to confirm that a meaningful error / fallback is shown
+  // to the user. If 502 ever starts looking like a 200 (or shows
+  // nothing) this matrix will catch it.
+  //
+  // /api/feed is excluded from the matrix because the stale
+  // FEED_FALLBACK_ARTICLES list (combined with filterPreviewableFeedArticles
+  // + isRecentFeedArticle) drops everything to zero — a separate site
+  // bug, not in scope for this spec.
+  const ERROR_CODES = [401, 403, 404, 502, 503];
+
+  for (const code of ERROR_CODES) {
+    test(`newsletter: ${code} → echoes the exact server-provided error text`, async ({ page, homePage }) => {
+      await page.route('**/api/subscribe', (route) =>
+        route.fulfill({
+          status: code,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: `Server returned ${code}` }),
+        }),
+      );
+      await homePage.goto();
+      await homePage.subscribe('user@example.com');
+      await expect(homePage.newsletterError).toBeVisible();
+      await expect(homePage.newsletterError).toContainText(`Server returned ${code}`);
+    });
+
+    test(`newsletter: ${code} without payload → default "Something went wrong"`, async ({ page, homePage }) => {
+      await page.route('**/api/subscribe', (route) =>
+        route.fulfill({ status: code, contentType: 'application/json', body: '{}' }),
+      );
+      await homePage.goto();
+      await homePage.subscribe('user@example.com');
+      await expect(homePage.newsletterError).toContainText('Something went wrong');
+    });
+
+    test(`article modal: ${code} → EXACT fallback string in reader`, async ({ page, homePage }) => {
+      await page.route('**/api/article-page**', (route) =>
+        route.fulfill({ status: code, contentType: 'text/html', body: 'err' }),
+      );
+      await homePage.goto();
+      await expect(homePage.feedCards.first()).toBeVisible({ timeout: 25_000 });
+      await homePage.openFeedArticle(0);
+      const reader = page.locator('#article-modal-reader');
+      await expect(reader).toHaveClass(/loaded/, { timeout: 15_000 });
+      // Every non-2xx code must produce the same string (script.js:981).
+      // If the frontend ever starts showing "Authorization required" on
+      // 401, this test will fail and surface the UX-matrix change.
+      await expect(reader).toContainText(
+        'Full reader preview is unavailable for this publisher. Showing the RSS preview.',
+      );
+    });
+
+    test(`chatbot: ${code} → EXACT "hello" fallback from getFallbackReply`, async ({ page, chatbotPage }) => {
+      await page.route('**/api/chat', (route) =>
+        route.fulfill({ status: code, contentType: 'application/json', body: '{}' }),
+      );
+      await chatbotPage.openAndConsent();
+      await chatbotPage.sendMessage('hello');
+      await expect(chatbotPage.finishedAiMessage).toContainText(
+        'Hey there! Ask me anything — AI testing, coding, science, history, or just chat.',
+        { timeout: 20_000 },
+      );
+    });
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 6. Performance — block images/fonts to speed up the page load
+  // ───────────────────────────────────────────────────────────────────────────
+  test('blocking images & fonts speeds up page load', async ({ page, homePage }) => {
+    await page.route('**/*', (route) => {
+      const t = route.request().resourceType();
+      if (t === 'image' || t === 'font' || t === 'media') return route.abort();
+      return route.continue();
+    });
+
+    const t0 = Date.now();
+    await homePage.goto();
+    await expect(homePage.liveFeedSection).toBeVisible();
+    const dt = Date.now() - t0;
+
+    // Not a fixed budget — sanity check that the page still loads.
+    // The main value of this test is the pattern itself: how to speed
+    // up CI by suppressing non-essential resources.
+    console.log(`page ready in ${dt}ms with images/fonts blocked`);
+    expect(dt).toBeLessThan(20_000);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes why the **RAG Eval Nightly** failure (24 passed, 3 failed, 89%) produced **no reaction** from the healing agent, and adds detailed agent reporting.

### Root cause
- `eval/ragas_eval.py` decided its exit code **only** from the *average* faithfulness/relevancy across all questions. Per-question pass/fail counts were written to `summary.json` for the report but never affected the exit code. With 24/27 passing, the averages stayed above threshold → script returned `0` → GitHub marked the run **success** → the auto-fix gate (`if conclusion == 'failure'`) never fired.

### Changes
1. **`eval/ragas_eval.py`** — fail the run when individual questions fail, via a new `ALLOWED_FAILURES` env gate (default `0` = any failure fails the build; set `-1` for legacy average-only behaviour). Now RAG failures conclude `failure` and the auto-fix gate fires.
2. **`.github/scripts/auto_fix_agent.py`** —
   - New **report-only path** for RAG/eval pipelines: the agent **never auto-patches** (root cause lives in the RAG app / knowledge base / eval dataset, which it must not edit). Instead it investigates, opens a **tracking issue**, and posts a detailed report.
   - **Detailed Investigation / Fix / Resolution report** posted to **#qa-agent-reports** for every failure — including test-code pipelines, even when no confident fix is found.
   - Test-code pipelines keep the existing PR flow (PR is opened for review; **never auto-merged**).
3. **`.github/workflows/auto-fix.yml`** — plumb `AGENT_REPORTS_CHANNEL_ID` (new `#qa-agent-reports` channel) and add `eval-report` to the artifact download filter so the agent can read the eval report/summary when triaging.

### Notes
- New Slack channel **#qa-agent-reports** created in AI/QA Moments; PW-CI bot added; `AGENT_REPORTS_CHANNEL_ID` secret set.
- Governance unchanged: the agent opens PRs/issues but **never merges**.

## Test plan
- [ ] Manually re-run **LLM Eval Nightly** (or wait for the 03:30 UTC cron); with current 3 failing questions it should now conclude **failure**.
- [ ] Confirm the auto-fix workflow then triggers and posts an Investigation/Fix/Resolution report to **#qa-agent-reports** + opens a tracking issue (no PR for RAG).
- [ ] Trigger a Playwright/LLM-judge failure and confirm a PR is opened AND a detailed report is posted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)