### PR TITLE
fix: auto-fix Playwright CI (deterministic tests) (dd11d5ac)

### DIFF
--- a/tests/api-smoke.spec.ts
+++ b/tests/api-smoke.spec.ts
@@ -33,6 +33,7 @@ type Probe = {
   // Optional structural assertion run against the parsed JSON body.
   assertBody?: (body: any) => void;
   note?: string;
+  upstream?: boolean;
 };
 
 const CONTRACTS: Record<string, Probe> = {
@@ -81,6 +82,7 @@ const CONTRACTS: Record<string, Probe> = {
     // long as we don't get 5xx-other or HTML.
     status: [200, 429, 503],
     json: true,
+    upstream: true,
     note: 'Implemented; LLM-backed, tolerates rate-limit responses.',
   },
   '/api/hallucination': {
@@ -192,7 +194,7 @@ async function runProbe(request: APIRequestContext, path: string, probe: Probe) 
 
 test.describe('API smoke — chat_server contracts', () => {
   for (const [path, probe] of Object.entries(CONTRACTS)) {
-    test(`${probe.method} ${path} → ${probe.status}${probe.note ? ` (${probe.note})` : ''}`,
+    test(`${probe.method} ${path} → ${probe.status}${probe.note ? ` (${probe.note})` : ''}${probe.upstream ? ' @upstream' : ''}`,
       async ({ request }) => {
         await runProbe(request, path, probe);
       },


### PR DESCRIPTION
## 🤖 Auto-fix: Playwright CI (deterministic tests)

**Failing CI run:** https://github.com/qa-apps/PW_alexpavsky/actions/runs/26704863700
**Head commit:** `dd11d5ac7019d0be2f301ccc87d3eb0b73286004`

### Changes applied
- tests/api-smoke.spec.ts: Add an upstream flag to the Probe type so LLM-backed endpoints can be tagged @upstream like /api/chat.
- tests/api-smoke.spec.ts: /api/attack-generator is LLM-backed and timed out at 10s in PURE CI (passed on retry). Mark it upstream so it follows the same exclusion pattern as the already-tagged /api/chat upstream test.
- tests/api-smoke.spec.ts: Append the @upstream tag to test names when probe.upstream is set so CI's --grep-invert "@upstream|LLM Judge" filter routes flaky LLM-dependent probes to the non-blocking job.

### Review checklist
- [ ] Tests pass locally (`npx playwright test` or `pytest`)
- [ ] No new `waitForTimeout` / `sleep` calls added
- [ ] Change is minimal and targeted to the failure

---
*Created automatically by local auto-fix agent (claude -p / Sonnet). Review carefully before merging.*
