### PR TITLE
ci(promptfoo): headless eval (no hang)

### DIFF
--- a/.github/workflows/promptfoo-basic.yml
+++ b/.github/workflows/promptfoo-basic.yml
@@ -55,7 +55,17 @@ jobs:
       - name: Run promptfoo eval
         id: eval
         continue-on-error: true
+        # Step-level cap so a hung eval can't eat the whole job — the
+        # always() Notify Slack step below still runs after a step timeout.
+        timeout-minutes: 15
         env:
+          # Non-interactive: promptfoo hangs with zero output in a non-TTY
+          # runner if it tries telemetry / update-check / a progress TUI.
+          # These + stdin from /dev/null keep it fully headless.
+          PROMPTFOO_DISABLE_TELEMETRY: "1"
+          PROMPTFOO_DISABLE_UPDATE: "1"
+          PROMPTFOO_DISABLE_SHARE: "1"
+          CI: "true"
           GROQ_API_KEY: ${{ secrets.GROQ_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           CEREBRAS_API_KEY: ${{ secrets.CEREBRAS_API_KEY }}
@@ -71,7 +81,8 @@ jobs:
           echo "Running promptfoo with $CONFIG"
           npx promptfoo eval -c "$CONFIG" \
             --max-concurrency 3 \
-            -o promptfoo-results.json
+            --no-progress-bar \
+            -o promptfoo-results.json </dev/null
 
       - name: Upload promptfoo results
         if: always()


### PR DESCRIPTION
Fixes the promptfoo-basic workflow hanging with zero output on a non-TTY runner. Adds PROMPTFOO_DISABLE_TELEMETRY/_UPDATE/_SHARE, --no-progress-bar, stdin </dev/null, and a 15-min step timeout so Notify Slack still fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)